### PR TITLE
Modify config.js to use async/await and bug fix

### DIFF
--- a/modules/config.js
+++ b/modules/config.js
@@ -17,103 +17,91 @@ module.exports = {
     },
 
     //Get the config from disk.
-    GetConfig() {
-        return new Promise((resolvec, rejectc) => {
-            try{
-                //If config is null, load it.
-                let filepathfull = this.GetConfigFullPath();
-    
-                //If the config file exists, read and parse it.
-                if(fs.existsSync(filepathfull)){
-                    this.config = JSON.parse(fs.readFileSync(filepathfull, 'utf8'));
-                    global.log.log("Loaded pre existing config");
-                    resolvec(this.config);
-                }
-                else{
-                    global.log.log("User does not have a config file, creating one");
-                    //Create default config
-                    this.config = {
-                        steam_directory: "",
-                        tf2_directory: "",
-                        current_mod_versions: []
-                    }
+    GetConfig: async function GetConfig() {
+        //If config is null, load it.
+        let filepathfull = this.GetConfigFullPath();
 
-                    //Try to populate the default values of the steam directory and tf2 directory automatically.
-                    this.config.steam_directory = GetSteamDirectory();
-
-                    global.log.log(`Auto locater for the users steam directory returned '${this.config.steam_directory}'`);
-
-                    if(this.config.steam_directory != "") {
-                        //Try to find the users tf2 directory automatically.
-                        this.GetTF2Directory(this.config.steam_directory).
-                        then((result) => {
-                            global.log.log("TF2 directory was found successfully at: " + result);
-                            this.config.tf2_directory = result;
-                            this.SaveConfig(this.config);
-                            resolvec(this.config);
-                        }).catch((e) => {
-                            //We failed to get the tf2 dir. Finish anyway.
-                            //The user is notified later if it is left blank.
-                            global.log.error("TF2 directory was not found automatically");
-                            this.SaveConfig(this.config);
-                            resolvec(this.config);
-                        });
-                    }
-                    else {
-                        //Resolve now without the steam dir or a tf2 dir.
-                        //User is told later anyway.
-                        this.SaveConfig(this.config);
-                        resolvec(this.config);
-                    }
-                }
+        //If the config file exists, read and parse it.
+        if(fs.existsSync(filepathfull)){
+            this.config = JSON.parse(fs.readFileSync(filepathfull, 'utf8'));
+            global.log.log("Loaded pre existing config");
+            return this.config;
+        } else {
+            global.log.log("User does not have a config file, creating one");
+            //Create default config
+            this.config = {
+                steam_directory: "",
+                tf2_directory: "",
+                current_mod_versions: []
             }
-            catch (e){
-                rejectc(e);
+
+            //Try to populate the default values of the steam directory and tf2 directory automatically.
+            this.config.steam_directory = GetSteamDirectory();
+
+            global.log.log(`Auto locater for the users steam directory returned '${this.config.steam_directory}'`);
+
+            if(this.config.steam_directory != "") {
+                //Try to find the users tf2 directory automatically.
+                try {
+                    let result = await this.GetTF2Directory(this.config.steam_directory)
+                    .catch((e) => {
+                        //We failed to get the tf2 dir. Finish anyway.
+                        //The user is notified later if it is left blank.
+                        global.log.error("TF2 directory was not found automatically");
+                    });
+
+                    global.log.log("TF2 directory was found successfully at: " + result);
+                    this.config.tf2_directory = result;
+                } finally {
+                    this.SaveConfig(this.config);
+                    return this.config;
+                }
+            } else {
+                //Resolve now without the steam dir or a tf2 dir.
+                //User is told later anyway.
+                this.SaveConfig(this.config);
+                return this.config;
             }
-        });
+        }
     },
 
     //This attempts to find the users tf2 directory automatically.
-    GetTF2Directory(steamdir) {
+    GetTF2Directory: async function GetTF2Directory(steamdir) {
         let tf2path = "steamapps/common/Team Fortress 2/";
-    
-        let p = new Promise((resolvet, rejectt) => {
-            //Check if tf2 is installed in the steam installation steamapps.
-            if (fs.existsSync(steamdir + tf2path)) {
-                let tf2path = steamdir + tf2path;
-                resolve(tf2path);
-            }
-            else {
-                //Check the library folders file and check all those for the tf2 directory.
-                let libraryfolders = `${steamdir}/steamapps/libraryfolders.vdf`;
-                if (fs.existsSync(libraryfolders)) {
-                    //How this works:
-                    //Read the lines of the libraryfolders
-                    //If we find a match with the regular expression, we have a possible other library folder.
-                    //We check this library folder to see if it has a tf2 install folder.
-                    //If yes, we use this!
-                    //If no, we just fail.
 
-                    let data = fs.readFileSync(libraryfolders, 'utf8');
-                    let lines = data.split("\n");
-                    for (let i = 0; i < lines.length; i++) {
-                        let result = pathStringRegex.exec(lines[i]);
-                        if (result) {
-                            if (result[2]) {
-                                let potentialPath = path.join(result[2], "/", tf2path);
-                                if(fs.existsSync(potentialPath)){
-                                    resolvet(potentialPath);
-                                }
+        //Check if tf2 is installed in the steam installation steamapps.
+        if (fs.existsSync(path.join(steamdir, tf2path))) {
+            tf2path = path.join(steamdir, tf2path);
+            return tf2path;
+        } else {
+            //Check the library folders file and check all those for the tf2 directory.
+            let libraryfolders = `${steamdir}/steamapps/libraryfolders.vdf`;
+            if (fs.existsSync(libraryfolders)) {
+                //How this works:
+                //Read the lines of the libraryfolders
+                //If we find a match with the regular expression, we have a possible other library folder.
+                //We check this library folder to see if it has a tf2 install folder.
+                //If yes, we use this!
+                //If no, we just fail.
+
+                let data = fs.readFileSync(libraryfolders, 'utf8');
+                let lines = data.split("\n");
+                for (let i = 0; i < lines.length; i++) {
+                    let result = pathStringRegex.exec(lines[i]);
+                    if (result) {
+                        if (result[2]) {
+                            let potentialPath = path.join(result[2], "/", tf2path);
+                            if(fs.existsSync(potentialPath)){
+                                return potentialPath;
                             }
                         }
                     }
-                    rejectt("No other tf2 libraries had TF2");
                 }
-                rejectt("TF2 not found in base install location, no other libraries found.");
+                throw new Error("No other tf2 libraries had TF2");
+            } else {
+                throw new Error("TF2 not found in base install location, no other libraries found.");
             }
-        });
-
-        return p;
+        }
     },
 
     GetConfigFullPath(){

--- a/modules/config.js
+++ b/modules/config.js
@@ -44,24 +44,17 @@ module.exports = {
                 //Try to find the users tf2 directory automatically.
                 try {
                     let result = await this.GetTF2Directory(this.config.steam_directory)
-                    .catch((e) => {
-                        //We failed to get the tf2 dir. Finish anyway.
-                        //The user is notified later if it is left blank.
-                        global.log.error("TF2 directory was not found automatically");
-                    });
 
                     global.log.log("TF2 directory was found successfully at: " + result);
                     this.config.tf2_directory = result;
-                } finally {
-                    this.SaveConfig(this.config);
-                    return this.config;
+                } catch {
+                    global.log.error("TF2 directory was not found automatically");
                 }
-            } else {
-                //Resolve now without the steam dir or a tf2 dir.
-                //User is told later anyway.
-                this.SaveConfig(this.config);
-                return this.config;
             }
+            //Return whether or not the TF2/Steam directory was found
+            //User is told later anyway.
+            this.SaveConfig(this.config);
+            return this.config;
         }
     },
 


### PR DESCRIPTION
**Progress on #7, GetConfig() and GetTF2Directory are made async and return a Promise by default.**

- **Fixed bug in GetTF2Directory() causing the TF2 directory to not be found was fixed by using path.join instead of string concatenation, as currently it checks for '...x86)/Steamsteamapps/Tea...'.**
- **Removed SaveConfig() duplication in GetConfig()**

Tested to be seemingly working fine, here's my test.js I have in modules/ if interested. I've just been renaming my TF2 directory and resetting the creators-tf-launcher folder in AppData to test.
```node
global.path = require("path");
global.fs = require("fs");
global.process = require("process");
global.os = require("os");
global.https = require("https");

const config = require("./config");

global.log = console
global.log.log = console.log;

// config.GetTF2Directory(config.GetSteamDirectory()).then((resolve, reject) => {
//     console.log(resolve);
// }).catch((e) => {
//     console.log(e);
// });

config.GetConfig().then((resolve, reject) => {
    console.log(resolve);
}).catch((e) => {
    console.log(e);
});
```

Few tests:
```
User does not have a config file, creating one
Auto locater for the users steam directory returned 'C:/Program Files (x86)/Steam'
TF2 directory was found successfully at: C:\Program Files (x86)\Steam\steamapps\common\Team Fortress 2\
Config file was saved.
{
  steam_directory: 'C:/Program Files (x86)/Steam',
  tf2_directory: 'C:\\Program Files (x86)\\Steam\\steamapps\\common\\Team Fortress 2\\',
  current_mod_versions: []
}
```
```
User does not have a config file, creating one
Auto locater for the users steam directory returned 'C:/Program Files (x86)/Steam'
TF2 directory was not found automatically
Config file was saved.
{
  steam_directory: 'C:/Program Files (x86)/Steam',
  tf2_directory: '',
  current_mod_versions: []
}
```
```
Loaded pre existing config
{
  steam_directory: 'C:/Program Files (x86)/Steam',
  tf2_directory: 'C:\\Program Files (x86)\\Steam\\steamapps\\common\\Team Fortress 2\\',
  current_mod_versions: []
}
```