### PR TITLE
Settings: user can reload TF2 directory from Steam directory

### DIFF
--- a/main.js
+++ b/main.js
@@ -247,3 +247,14 @@ ipcMain.on("Remove-Mod", async(event, arg) => {
         });
     }
 });
+
+
+ipcMain.on("config-reload-tf2directory", async (event, steamdir) => {
+
+    const tf2dir = await config.GetTF2Directory(steamdir);
+    if (tf2dir && tf2dir != "")
+        global.config.steam_directory = steamdir;
+        global.config.tf2_directory = tf2dir;
+
+    event.reply("GetConfig-Reply", global.config);
+});

--- a/settings-page/preload.js
+++ b/settings-page/preload.js
@@ -13,6 +13,7 @@ window.addEventListener("DOMContentLoaded", () => {
     var btn_showCfg = document.getElementById("config-show-button");
     var btn_showCfgClose = document.getElementById("config-dontshow-button");
     var btn_openconfigloc = document.getElementById("open-config-location");
+    var btn_reload = document.getElementById("reload-button");
 
     log.info("Asking for config");
     ipcRenderer.send("GetConfig", "");
@@ -25,6 +26,10 @@ window.addEventListener("DOMContentLoaded", () => {
     }
     btn_openconfigloc.onclick = () => {
         ipcRenderer.send("open-config-location", "");
+    };
+    btn_reload.onclick = () => {
+        const steamdir = document.getElementById("steam_directory").value
+        ipcRenderer.send("config-reload-tf2directory", steamdir);
     };
 });
 

--- a/settings-page/settings.html
+++ b/settings-page/settings.html
@@ -5,6 +5,7 @@
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'">
     <meta http-equiv="X-Content-Security-Policy" content="default-src 'self'; script-src 'self'">
     <title>Settings</title>
+    <link rel="stylesheet" href="../node_modules/@mdi/font/css/materialdesignicons.min.css">
     <link rel="stylesheet" href="../generalstyle.css">
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="../fonts/fonts.css">
@@ -12,7 +13,13 @@
   <body>
     <h1>Settings</h1>
     <p class="dirconfig">Steam Directory<br><input id="steam_directory" type="text"></p>
-    <p class="dirconfig">TF2 Directory<br><input id="tf2_directory" type="text"></p>
+    <div class="inputLabelRow">
+      <p>TF2 Directory</p>
+    </div>
+    <div class="inputRow">
+      <input id="tf2_directory" type="text" class="inputColumn">
+      <button type="button" class="buttonColumn reload-button mdi mdi-reload" id="reload-button"></button>
+    </div>
     <div id="boxofbuttons">
       <button type="button" class="config-button" id="config-show-button">Show Config Contents</button>
       <button type="button" class="config-button" id="open-config-location">Open Config/Log Folder</button>

--- a/settings-page/style.css
+++ b/settings-page/style.css
@@ -113,3 +113,61 @@ p {
 }
 
 #config-dontshow-button:hover { background-color: #999; }
+
+
+.inputLabelRow {
+    display: flex;
+    flex-direction: row;
+    width: 55%;
+    text-align: center;
+    font-family: Roboto Light, Arial, sans-serif;
+    font-size: 20px;
+    margin: 0px;
+}
+
+.inputLabelRow p {
+    width: 100%;
+    margin: 0px;
+}
+.inputRow
+{
+    display: flex;
+    flex-direction: row;
+    width: 49.5%;
+    text-align: center;
+    margin: 0px 0px 10px 0px;
+    padding: 5px;
+}
+
+.inputColumn
+{
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+
+    border: 0px;
+    border-radius: 5px;
+    box-shadow: inset 0px 0px 3px #000;
+}
+
+.buttonColumn
+{
+    display: flex;
+    flex-direction: column;
+    flex: 0 0 auto;
+}
+
+.reload-button {
+    padding: 8px;
+    border-radius: 5px;
+    cursor: pointer;
+    transition: 0.2s;
+    border: 0;
+    outline: 0;
+    margin-left: 10px;
+    box-shadow: inset 0px 0px 3px #000;
+}
+
+.reload-button:hover {
+    background-color: #999;
+}


### PR DESCRIPTION
added a button next to the TF2 directory textbox
when clicked the launcher tries to recognize the TF2 directory again using the Steam directory as base (already present functionality)
if a TF2 directory is found, it is set in the config and the settings-page is notified about the new config