### PR TITLE
Refactor ModManager and ModListLoader, clean formatting

### DIFF
--- a/modules/mod_list_loader.ts
+++ b/modules/mod_list_loader.ts
@@ -1,9 +1,8 @@
 import fs from "fs";
 import path from "path";
 import https from "https";
-import {Utilities} from "./utilities";
+import { Utilities } from "./utilities";
 import ElectronLog from "electron-log";
-import { remote } from "electron";
 
 //URLs to try to get mod lists from.
 //More than one allows fallbacks.
@@ -18,23 +17,22 @@ const localModListName = "mods.json";
  * Responsible for providing the latest mod list avaliable.
  */
 class ModListLoader {
+    private static lastDownloaded: ModList;
+    private static localModList: ModList;
 
-    private static lastDownloaded : ModList;
-    private static localModList : ModList;
-
-    public static LoadLocalModList(){
+    public static LoadLocalModList() {
         this.localModList = this.GetLocalModList();
     }
 
-    public static GetModList() : ModList {
+    public static GetModList(): ModList {
         return this.localModList;
     }
 
     /**
      * Update the local mod list file on disk to contain the latest data we found.
      */
-    public static UpdateLocalModList() : Boolean {
-        if(this.lastDownloaded != null && this.localModList.version < this.lastDownloaded.version){
+    public static UpdateLocalModList(): boolean {
+        if (this.lastDownloaded != null && this.isLocalModListOutdated()) {
             let configPath = path.join(Utilities.GetDataFolder(), localModListName);
             fs.writeFileSync(configPath, JSON.stringify(this.lastDownloaded));
             return true;
@@ -45,118 +43,129 @@ class ModListLoader {
     /**Check if there is a newer mod list online.
      * Also checks if the internal version is newer than the local, written version.
      */
-    public static async CheckForUpdates() : Promise<boolean> {
+    public static async CheckForUpdates(): Promise<boolean> {
         ElectronLog.log("Checking for modlist updates");
-        var data = new Array<any>();
 
-        try{
-            for(let i = 0; i < modListURLs.length; i++){
-                var url = modListURLs[i];
-                //Soo ts shuts up about the method returning any, which it must do otherwise it gets mad.
-                //Seems its not very good with async hidden promises...
-                var remoteModList;
-                try{
-                    remoteModList = await <ModList><unknown>this.TryGetModList(url);
-                }
-                catch {
-                    continue;
-                }
+        try {
+            this.loadModList();
 
-                //Break if we have a valid mod list. If we have null, try again.
-                if (remoteModList != null && remoteModList != undefined){
-                    this.lastDownloaded = remoteModList;
-                    break;
-                } 
-            }
-
-            if(this.lastDownloaded != null && this.lastDownloaded.hasOwnProperty("version")){
+            if (this.lastDownloaded != null && this.lastDownloaded.hasOwnProperty("version")) {
                 ElectronLog.log(`Local mod list version: ${this.localModList.version}, Remote mod list version: ${this.lastDownloaded.version}.`);
-                return this.localModList.version < this.lastDownloaded.version;
+                return this.isLocalModListOutdated();
             }
+            ElectronLog.log("No mod list updates found.");
+            return false;
         }
         catch (error) {
             console.error("Failed to check for updates. " + error.toString());
             return false;
         }
-        ElectronLog.log("No mod list updates found.");
-        return false;
     }
 
-    private static async TryGetModList(url : string) : Promise<ModList> {
+    private static async loadModList(): Promise<void> {
+        for (let i = 0; i < modListURLs.length; i++) {
+            var url = modListURLs[i];
+            //Soo ts shuts up about the method returning any, which it must do otherwise it gets mad.
+            //Seems its not very good with async hidden promises...
+            var remoteModList;
+            try {
+                remoteModList = await this.TryGetModList(url);
+            }
+            catch {
+                continue;
+            }
+
+            //Break if we have a valid mod list. If we have null, try again.
+            if (remoteModList != null && remoteModList != undefined) {
+                this.lastDownloaded = remoteModList;
+                break;
+            }
+        }
+    }
+
+    private static async TryGetModList(url: string): Promise<ModList> {
         return new Promise((resolve, reject) => {
-        ElectronLog.log("Trying to get mod list from: " + url);
-        var data = new Array<any>();
-        let req = https.get(url, res => {
-            console.log(`statusCode: ${res.statusCode}`);
+            ElectronLog.log("Trying to get mod list from: " + url);
+            var data = new Array<any>();
+            let request = https.get(url, res => {
+                console.log(`statusCode: ${res.statusCode}`);
 
-            res.on('data', d => {
-                if(res.statusCode != 200){
-                    resolve(null);
-                }
-                
-                data.push(d);
+                res.on('data', d => {
+                    if (res.statusCode != 200) {
+                        resolve(null);
+                    }
+
+                    data.push(d);
+                });
+
+                res.on("end", () => {
+                    try {
+                        var buffer = Buffer.concat(data);
+                        let parsed = JSON.parse(buffer.toString());
+                        resolve(parsed);
+                    }
+                    catch (error) {
+                        //Json parsing failed soo reject.
+                        ElectronLog.error(`Failed to parse json in TryGetModList request for ${url}, error: ${error.toString()}`);
+                        resolve(null);
+                    }
+                });
             });
 
-            res.on("end",  () => {
-                try{
-                    var buf = Buffer.concat(data);
-                    let parsed = JSON.parse(buf.toString());
-                    resolve(parsed);
-                }
-                catch (error){
-                    //Json parsing failed soo reject.
-                    ElectronLog.error(`Failed to parse json in TryGetModList request for ${url}, error: ${error.toString()}`);
-                    resolve(null);
-                }
+            request.on('error', (error: string | undefined) => {
+                ElectronLog.error("General request error in a TryGetModList request, error: " + error.toString());
+                resolve(null);
             });
-        });
-        
-        req.on('error', (error: string | undefined) => {
-            ElectronLog.error("General request error in a TryGetModList request, error: " + error.toString());
-            resolve(null);
-        });
-        
-        req.end();
+
+            request.end();
         });
     }
 
-    public static GetLocalModList() : ModList {
+    public static GetLocalModList(): ModList {
         //Try to load file from our local data, if that doesn't exist, write the internal mod list and return that.
-        var internalModListJSON = fs.readFileSync(path.resolve(__dirname, "..", "internal", "mods.json"), {encoding:"utf-8"});
-        var internalModList = <ModList>JSON.parse(internalModListJSON);
-        let configPath = path.join(Utilities.GetDataFolder(), localModListName);
+        const filePath = path.resolve(__dirname, "..", "internal", localModListName);
+        var internalModListJson = fs.readFileSync(filePath, { encoding: "utf-8" });
+        var internalModList = <ModList>JSON.parse(internalModListJson);
 
-        if(fs.existsSync(configPath)){
-            var localConfig = <ModList>JSON.parse(fs.readFileSync(configPath, {encoding:"utf-8"}));
-            if(localConfig.version > internalModList.version){
+        let configPath = this.getConfigPath();
+        if (fs.existsSync(configPath)) {
+            var localConfig = <ModList>JSON.parse(fs.readFileSync(configPath, { encoding: "utf-8" }));
+            if (localConfig.version > internalModList.version) {
                 return localConfig;
             }
         }
 
         //Write the internal mod list then return that too.
         //We also want to re write the internal mod list if its a higher version.
-        fs.writeFileSync(configPath, internalModListJSON);
-        return <ModList>JSON.parse(internalModListJSON);
+        fs.writeFileSync(configPath, internalModListJson);
+        return <ModList>JSON.parse(internalModListJson);
     }
 
-    public static DeleteLocalModList() : Boolean {
-        let configPath = path.join(Utilities.GetDataFolder(), localModListName);
-        if(fs.existsSync(configPath)){
+    public static DeleteLocalModList(): Boolean {
+        let configPath = this.getConfigPath();
+        if (fs.existsSync(configPath)) {
             fs.unlinkSync(configPath);
             return true;
         }
         return false;
     }
+
+    private static isLocalModListOutdated() {
+        return this.localModList.version < this.lastDownloaded.version;
+    }
+
+    private static getConfigPath(): string {
+        return path.join(Utilities.GetDataFolder(), localModListName);
+    }
 }
 
-class ModList
-{
+class ModList {
     version: number;
     mods: Array<ModListEntry>;
 
-    public GetMod(name : any) : ModListEntry{
-        for(var entry of this.mods){
-            if(entry.name == name){
+    public GetMod(name: any): ModListEntry {
+        for (var entry of this.mods) {
+            if (entry.name == name) {
                 return entry;
             }
         }
@@ -165,8 +174,7 @@ class ModList
     }
 }
 
-class ModListEntry
-{
+class ModListEntry {
     name: string;
     blurb: string;
     icon: string;

--- a/modules/mod_manager.ts
+++ b/modules/mod_manager.ts
@@ -25,14 +25,18 @@ const loadingTextStyle = {
     color: "ghostwhite"
 }
 
-type State = "NOT_INSTALLED" | "INSTALLED" | "UPDATE";
+export enum State {
+    NotInstalled = "NOT_INSTALLED",
+    Installed = "INSTALLED",
+    Update = "UPDATE"
+};
 
 class DownloadedFile {
     buffer: Buffer;
     name: string;
     extension: string;
 
-    constructor(buffer, name){
+    constructor(buffer, name) {
         this.buffer = buffer;
         this.name = name;
 
@@ -43,273 +47,228 @@ class DownloadedFile {
 
 class ModManager {
 
-    //Export variables.
-    static all_mods_data: ModList
-    static currentModData: ModListEntry
-    static currentModVersion = 0
-    static currentModState: State;
-    static currentModVersionRemote = 0
-    static downloadWindow: BrowserWindow = null;
-    static files_object: any;
-    static source_manager: ModInstallSource;
+    modList: ModList
+    currentModData: ModListEntry
+    currentModVersion = 0
+    currentModState: State;
+    currentModVersionRemote = 0
+    downloadWindow: BrowserWindow = null;
+    modInstallSource: ModInstallSource;
 
     //Sets up the module.
-    static async Setup(){
-        this.all_mods_data = ModListLoader.GetModList();
-
+    async Setup(): Promise<any> {
+        this.modList = ModListLoader.GetModList();
         return await filemanager.Init();
     }
 
     //Change the currently selected mod, return its installation button text.
-    static async ChangeCurrentMod(name){
-        //Get this mods data and store it for use.
-        this.currentModData = this.GetModDataByName(name);
-        this.currentModVersion = this.GetCurrentModVersionFromConfig(name);
-        this.currentModState = "NOT_INSTALLED";
-        this.currentModVersionRemote = 0;
+    async ChangeCurrentMod(name): Promise<void> {
+        this.loadModData(name);
+        this.setModInstallSource();
 
-        ElectronLog.log(`Set current mod to: ${this.currentModData.name}`);
-
-        //Setup the source manager object depending on the type of the mod.
-        switch(this.currentModData.install.type){
-            case "jsonlist":
-                this.source_manager = new JsonListSource(this.currentModData.install);
-                break;
-            case "github":
-                this.source_manager = new GithubSource(this.currentModData.install);
-                break;
-            default:
-                this.source_manager = null;
-                throw new Error("Mod install type was not recognised: " + this.currentModData.install.type);
-        }
-
-        //We do not have a version for this mod. Method to use is install.
-        if(this.currentModVersion == null || this.currentModVersion == 0){
+        if (this.currentModNotInstalled()) {
             try {
-                const version = await this.source_manager.GetLatestVersionNumber();
-                this.currentModState = "NOT_INSTALLED";
-                this.currentModVersionRemote = version;
-                return "Install";
+                this.currentModVersionRemote = await this.modInstallSource.GetLatestVersionNumber();
+                this.currentModState = State.NotInstalled;
             } catch (e) {
                 throw new errors.InnerError("Failed to get mod version: " + e.toString(), e)
             }
         }
-        else {
-            //We have a version, now we need to determine if there is an update or not.
-            const version = await this.source_manager.GetLatestVersionNumber();
-            
-            //Compare the currently selected version number to this one. If ours is smaller, update. If not, do nothing.
-            this.currentModVersionRemote = version;
 
-            if(version > this.currentModVersion) 
-                this.currentModState = "UPDATE";
-            else 
-                this.currentModState = "INSTALLED";
-
-            //Time to resolve with the text to show on the button
-            switch(this.currentModState){
-                case "INSTALLED":
-                    return "Installed";
-                case "UPDATE":
-                    return "Update";
-                default:
-                    return "Install";
-            }
-        }
+        //Time to resolve with the text to show on the button
+        this.currentModVersionRemote = await this.modInstallSource.GetLatestVersionNumber();
+        this.currentModState = (this.currentModVersionRemote > this.currentModVersion) ? State.Update : State.Installed;
     }
 
     //Trigger the correct response to the current mod depending on its state.
     //This is called when the Install / Update / Installed button is pressed in the UI.
-    static async ModInstallPlayButtonClick(){
+    async ModInstallPlayButtonClick(): Promise<void> {
         ElectronLog.log("Install button was clicked! Reacting based on state: " + this.currentModState)
-        if (this.currentModData == null){
+        if (this.currentModData == null) {
             this.FakeClickMod();
             await ErrorDialog("Mod data was not able to be read.\nPlease report this error.", "Mod Install Start Error")
             return;
         }
 
-        switch(this.currentModState){
-            case "NOT_INSTALLED":
-                //We should try to install this mod!
-                //Before we try anything we need to validate the tf2 install directory. Otherwise downloading is a waste.
-                ElectronLog.log("Will validate TF2 path before starting download...");
-                if(!await ValidateTF2Dir()){                
-                    this.FakeClickMod();
-                    ElectronLog.error("Ending Install attempt now as validation failed!");
-                    return;
-                }
-                ElectronLog.log("TF2 Path was validated.");
-                    
-                //Perform mod download and install.
-                try {
-                    const _url = await this.source_manager.GetFileURL();
-                    ElectronLog.log("Successfuly got mod install file urls. Will proceed to try to download them.");
-                    await this.ModInstall(_url);
-                    await this.SetupNewModAsInstalled();
-                } catch (e) {
-                    this.FakeClickMod();
-                    await ErrorDialog(e, "Mod Begin Install Error");
-                }
-                
+        switch (this.currentModState) {
+            case State.NotInstalled:
+                this.installMod();
                 break;
-
-            case "UPDATE":
-                //We should try to update this mod!
-
-                //Setup the message to include the version if we have the data.
-                //Really we should for this state to be active but best to be sure.
-                ElectronLog.log("Asking user if they want to update this mod.");
-                let version = await this.source_manager.GetLatestVersionNumber();
-                let displayVersion = await this.source_manager.GetDisplayVersionNumber();
-                let update_msg = `Would you like to update this mod to version "${displayVersion}"?`;
-                //Ask if the users wants to update or not
-                
-                const button = await dialog.showMessageBox(Main.mainWindow, {
-                    type: "question",
-                    title: "Update",
-                    message: update_msg,
-                    buttons: ["Yes", "Cancel"],
-                    cancelId: 1
-                });
-                if(button.response == 0) {
-                    //Do the update!
-                    ElectronLog.log("Starting update process...");
-                    await this.UpdateCurrentMod();
-                }
+            case State.Update:
+                await this.updateMod();
                 break;
-            default:
+            case State.Installed:
                 ElectronLog.error("Somehow the install button was clicked when the mod is in the installed state.");
                 break;
+            default:
+                break;
+        }
+    }
+
+    private async installMod() {
+        //Before we try anything we need to validate the tf2 install directory. Otherwise downloading is a waste.
+        ElectronLog.log("Will validate TF2 path before starting download...");
+        const validated = this.validate();
+        if (!validated) {
+            ElectronLog.error("Ending Install attempt now as validation failed!");
+            return;
+        }
+        ElectronLog.log("TF2 Path was validated.");
+
+        try {
+            const _url = await this.modInstallSource.GetFileURL();
+            ElectronLog.log("Successfuly got mod install file urls. Will proceed to try to download them.");
+            await this.ModInstall(_url);
+            await this.SetupNewModAsInstalled();
+        } catch (e) {
+            this.FakeClickMod();
+            await ErrorDialog(e, "Mod Begin Install Error");
+        }
+    }
+
+    private async validate(): Promise<boolean> {
+        if (!await ValidateTF2Dir()) {
+            this.FakeClickMod();
+            return false;
+        }
+        return true;
+    }
+
+    private async updateMod(): Promise<void> {
+        //Setup the message to include the version if we have the data.
+        //Really we should for this state to be active but best to be sure.
+        ElectronLog.log("Asking user if they want to update this mod.");
+        let version = await this.modInstallSource.GetLatestVersionNumber();
+        let displayVersion = await this.modInstallSource.GetDisplayVersionNumber();
+        //Ask if the users wants to update or not
+        const button = await dialog.showMessageBox(Main.mainWindow, {
+            type: "question",
+            title: "Update",
+            message: `Would you like to update this mod to version "${displayVersion}"?`,
+            buttons: ["Yes", "Cancel"],
+            cancelId: 1
+        });
+        if (button.response == 0) {
+            //Do the update!
+            ElectronLog.log("Starting update process...");
+            await this.UpdateCurrentMod();
         }
     }
 
     //Attempt an update. If possible then we do it. Will try to do it incrementally or a full re download.
-    static async UpdateCurrentMod() {
+    private async UpdateCurrentMod(): Promise<void> {
         //Validate tf2 dir, then make sure we have the current data for the mod.
-        if (!await ValidateTF2Dir()) {
-            this.FakeClickMod();
+        const validated = this.validate();
+        if (!validated) {
             return;
         }
 
-        //Re validate the latest version is higher than ours.
-        const version = await this.source_manager.GetLatestVersionNumber();
+        const latestVersion = await this.modInstallSource.GetLatestVersionNumber();
+        if (this.currentModVersion > latestVersion) {
+            return;
+        }
 
         try {
-            //Compare the currently selected version number to this one. If ours is smaller, update. If not, do nothing.
-
-            if (version > this.currentModVersion) {
-                //Check mod type.
-                if (this.currentModData.install.type == "jsonlist") {
-                    //For an update, we will check if there is a list of update archives and try to create a list of ones to download.
-                    //Then we can incrementally update hopefully and download a lot less.
-                    let jsonSourceManager = <JsonListSource>this.source_manager;
-                    const data = await jsonSourceManager.GetJsonData();
-                    
-                    var urls = [];
-                    if (data.hasOwnProperty("PatchUpdates") && data.PatchUpdates.length > 0) {
-                        //There should be urls to patch zips for each update.
-                        let patchObjects = data.PatchUpdates;
-                        let patchURLS = [];
-                        patchObjects.forEach((patch) => {
-                            if (patch.Version > this.currentModVersion) patchURLS.push(patch);
-                        });
-
-                        //Sort the urls soo we apply updates from the oldest update to the newest.
-                        patchURLS.sort((a, b) => {
-                            //We want to sort smaller version numbers FIRST
-                            //Soo they get applied first later.
-                            if (a.Version > b.Version) return 1;
-                            if (a.Version < b.Version) return -1;
-
-                            return 0;
-                        });
-
-                        //Get out the urls for easier use later.
-                        for (let i = 0; i < patchURLS.length; i++) {
-                            urls.push(patchURLS[i].DownloadURL);
-                        }
-                    }
-                        
-                    if(urls.length > 0) {
-                        ElectronLog.log("Incremental update will begin for current mod using the following archive urls: " + urls.toString());
-                        await this.ModInstall(urls);
-                    
-                        //Update the version for the mod.
-                        
-                        SetNewModVersion(this.currentModVersionRemote, this.currentModData.name);
-
-                        //Save the config changes.
-                        await config.SaveConfig(Main.config);
-
-                        this.FakeClickMod();
-
-                        await dialog.showMessageBox(Main.mainWindow, {
-                            type: "info",
-                            title: "Mod Update",
-                            message: `Mod update for ${this.currentModData.name} was completed successfully.`,
-                            buttons: ["OK"]
-                        });
-                    }
-                    else {
-                        //We need to update using the main zip. Not ideal but works.
-                        ElectronLog.warn("Update source does not have patch data! Will have to download again fully.");
-                        const _url = await this.source_manager.GetFileURL();
-                        await this.ModInstall(_url);
-                        SetNewModVersion(this.currentModVersionRemote, this.currentModData.name);
-
-                        //Save the config changes.
-                        await config.SaveConfig(Main.config);
-
-                        this.FakeClickMod();
-
-                        await dialog.showMessageBox(Main.mainWindow, {
-                            type: "info",
-                            title: "Mod Update",
-                            message: `Mod update for ${this.currentModData.name} was completed successfully.`,
-                            buttons: ["OK"]
-                        });
-                    }
-                }
-                else if (this.currentModData.install.type == "github") {
-                    //Current mod is not a jsonlist type. Just get and install the latest.
-                    const _url = await this.source_manager.GetFileURL();
-                    ElectronLog.log("Mod is type GitHub, will update using the most recent release url: " + _url);
-                    await this.ModInstall(_url);
-                    SetNewModVersion(this.currentModVersionRemote, this.currentModData.name);
-                    //Save the config changes.
-                    await config.SaveConfig(Main.config);
-
-                    this.FakeClickMod();
-
-                    await dialog.showMessageBox(Main.mainWindow, {
-                        type: "info",
-                        title: "Mod Update",
-                        message: `Mod update for ${this.currentModData.name} was completed successfully.`,
-                        buttons: ["OK"]
-                    });
-                }
-                else {
-                    ElectronLog.error("Unknown mod type found during update attempt.");
-                    await ErrorDialog("Unknown mod type found during update attempt.", "Error");
-                }
+            //Check mod type.
+            if (this.currentModData.install.type == "jsonlist") {
+                //For an update, we will check if there is a list of update archives and try to create a list of ones to download.
+                //Then we can incrementally update hopefully and download a lot less.
+                await this.updateWithUpdateArchives();
             }
-            
+            else if (this.currentModData.install.type == "github") {
+                //Current mod is not a jsonlist type. Just get and install the latest.
+                ElectronLog.log("Mod is type GitHub, will update using the most recent release url.");
+                await this.updateWithLatestUrl();
+            }
+            else {
+                ElectronLog.error("Unknown mod type found during update attempt.");
+                await ErrorDialog("Unknown mod type found during update attempt.", "Error");
+            }
+
         } catch (e) {
-            await ErrorDialog(e, "Mod Update Error"); 
+            await ErrorDialog(e, "Mod Update Error");
         }
     }
 
-    static async ModInstall(contentURL){
-        let urlArray;
-        if(Array.isArray(contentURL)) urlArray = contentURL;
-        else{
-            urlArray = [];
-            urlArray.push(contentURL);
+    private async updateWithUpdateArchives(): Promise<void> {
+        var patchUrls = await this.loadPatchUrls();
+
+        if (patchUrls.length > 0) {
+            ElectronLog.log("Incremental update will begin for current mod using the following archive urls: " + patchUrls.toString());
+            await this.updateModWithUrls(patchUrls);
         }
-        
-        try {   
-            const files = await DownloadFiles_UI(urlArray);     
-            try {        
+        else {
+            ElectronLog.warn("Update source does not have patch data! Will have to download again fully.");
+            await this.updateWithLatestUrl();
+        }
+    }
+
+    private async updateWithLatestUrl() {
+        const url = await this.modInstallSource.GetFileURL();
+        await this.updateModWithUrls(url);
+    }
+
+    private async updateModWithUrls(url: any) {
+        await this.ModInstall(url);
+        SetNewModVersion(this.currentModVersionRemote, this.currentModData.name);
+        await config.SaveConfig(Main.config);
+
+        this.FakeClickMod();
+        await dialog.showMessageBox(Main.mainWindow, {
+            type: "info",
+            title: "Mod Update",
+            message: `Mod update for ${this.currentModData.name} was completed successfully.`,
+            buttons: ["OK"]
+        });
+    }
+
+    private async loadPatchUrls(): Promise<any[]> {
+        let jsonSourceManager = <JsonListSource>this.modInstallSource;
+        const patchData = await jsonSourceManager.GetJsonData();
+
+        var patchUrls = [];
+        if (patchData.hasOwnProperty("PatchUpdates") && patchData.PatchUpdates.length > 0) {
+            //There should be urls to patch zips for each update.
+            let patchObjects = patchData.PatchUpdates;
+            let patchURLS = [];
+            patchObjects.forEach((patch) => {
+                if (patch.Version > this.currentModVersion)
+                    patchURLS.push(patch);
+            });
+
+            //Sort the urls soo we apply updates from the oldest update to the newest.
+            patchURLS.sort((a, b) => {
+                //We want to sort smaller version numbers FIRST
+                //Soo they get applied first later.
+                if (a.Version > b.Version)
+                    return 1;
+                if (a.Version < b.Version)
+                    return -1;
+
+                return 0;
+            });
+
+            //Get out the urls for easier use later.
+            for (let i = 0; i < patchURLS.length; i++) {
+                patchUrls.push(patchURLS[i].DownloadURL);
+            }
+        }
+        return patchUrls;
+    }
+
+    private async ModInstall(contentUrl): Promise<void> {
+        let urls;
+        if (Array.isArray(contentUrl)) {
+            urls = contentUrl;
+        }
+        else {
+            urls = [];
+            urls.push(contentUrl);
+        }
+
+        try {
+            const files = await DownloadFiles_UI(urls);
+            try {
                 await this.InstallFiles(files);
             } catch (e) {
                 await ErrorDialog(e, "Mod Install Error"); this.FakeClickMod();
@@ -320,20 +279,22 @@ class ModManager {
     }
 
     //Set up the config information to actually define this mod as installed. MUST BE DONE.
-    static async SetupNewModAsInstalled(){
+    async SetupNewModAsInstalled(): Promise<void> {
         //Finish up the installation process.
         //Set the current version of the mod in the config.
 
         let versionUpdated = SetNewModVersion(this.currentModVersionRemote, this.currentModData.name);
 
-        //If we didnt update the version of an exstisting object. Add it.
-        if(!versionUpdated) Main.config.current_mod_versions.push({name: this.currentModData.name, version: this.currentModVersionRemote})
+        //If we didnt update the version of an existing object. Add it.
+        if (!versionUpdated) {
+            Main.config.current_mod_versions.push({
+                name: this.currentModData.name,
+                version: this.currentModVersionRemote
+            })
+        }
 
-        //Save the config changes.
         await config.SaveConfig(Main.config);
-
-        this.currentModState = "INSTALLED";
-
+        this.currentModState = State.Installed;
         this.FakeClickMod();
 
         await dialog.showMessageBox(Main.mainWindow, {
@@ -344,21 +305,33 @@ class ModManager {
         });
     }
 
-    static async RemoveCurrentMod() {
+    async RemoveCurrentMod(): Promise<void> {
         //Do nothing if this mod is not installed or if there is no mod data.
-        if(this.currentModData == null || this.currentModState == "NOT_INSTALLED") return;
+        if (this.currentModData == null || this.currentModState == "NOT_INSTALLED") {
+            return;
+        }
+
         var progressBar;
         try {
             //Load file list object
-            let files_object = await filemanager.GetFileList(this.currentModData.name);
+            let fileList = await filemanager.GetFileList(this.currentModData.name);
             var running = true;
 
-            if(files_object.files != null && files_object.files.length > 0){
+            if (fileList.files == null || fileList.files.length == 0) {
+                await dialog.showMessageBox(Main.mainWindow, {
+                    type: "error",
+                    title: "Mod Removal Error",
+                    message: "Mod cannot be removed. Please try to remove them manually.",
+                    buttons: ["OK"]
+                });
+            }
+
+            if (fileList.files != null && fileList.files.length > 0) {
                 progressBar = new ProgressBar({
                     indeterminate: false,
                     text: "Removing Mod Files",
                     detail: "Starting Removal...",
-                    maxValue: files_object.files.length,
+                    maxValue: fileList.files.length,
                     abortOnError: true,
                     closeOnComplete: false,
                     browserWindow: {
@@ -371,16 +344,16 @@ class ModManager {
                         title: "Removing Mod Files",
                         backgroundColor: "#2b2826",
                         closable: true
-                        },
-                        style: {
-                            text: loadingTextStyle,
-                            detail: loadingTextStyle,
-                            value: loadingTextStyle
-                        }
-                    }, Main.app);
+                    },
+                    style: {
+                        text: loadingTextStyle,
+                        detail: loadingTextStyle,
+                        value: loadingTextStyle
+                    }
+                }, Main.app);
 
-                    //Setup events to display data.
-                    progressBar
+                //Setup events to display data.
+                progressBar
                     .on('completed', () => {
                         progressBar.detail = 'Removal Done.';
                     })
@@ -393,79 +366,72 @@ class ModManager {
                         progressBar.detail = `${value} files removed out of ${progressBar.maxValue}`;
                     });
 
-                for(var i = 0; i < files_object.files.length; i++){
-                    if(!running) return;
+                for (var i = 0; i < fileList.files.length; i++) {
+                    if (!running) {
+                        return;
+                    }
 
-                    ElectronLog.log("Deleting file: " + files_object.files[i]);
+                    ElectronLog.log("Deleting file: " + fileList.files[i]);
                     //If the file exists, delete it.
-                    if(await fsPromises.fileExists(files_object.files[i])) await fsPromises.unlink(files_object.files[i]);
+                    if (await fsPromises.fileExists(fileList.files[i])) {
+                        await fsPromises.unlink(fileList.files[i]);
+                    }
                     progressBar.value = i + 1;
                 }
 
-                await Delay(300);        
+                await Delay(300);
                 running = false;
                 progressBar.setCompleted();
                 progressBar.close();
 
-                if(await fsPromises.fileExists(files_object.files[0])){
+                if (await fsPromises.fileExists(fileList.files[0])) {
                     await ErrorDialog(`Mod Removal Failed, TF2 may be using these files still. You must close TF2 to remove a mod.`, "Removal Error");
                     this.FakeClickMod();
                     return;
                 }
 
-                //Remove mod file list.
                 await filemanager.RemoveFileList(this.currentModData.name);
-
-                //Remove mod from current config
-                for(let i = 0; i < Main.config.current_mod_versions.length; i++){
-                    let element = Main.config.current_mod_versions[i];
-                    if(element.name && element.name == this.currentModData.name){
-                        Main.config.current_mod_versions.splice(i, 1);
-                    }
-                }
-                await config.SaveConfig(Main.config);
+                await this.removeModFromConfig();
 
                 await dialog.showMessageBox(Main.mainWindow, {
                     type: "info",
                     title: "Mod Removal Complete",
-                    message: `The mod "${this.currentModData.name}" has been removed successfully.\n${files_object.files.length} files were removed.`,
+                    message: `The mod "${this.currentModData.name}" has been removed successfully.\n${fileList.files.length} files were removed.`,
                     buttons: ["OK"]
                 });
 
                 this.FakeClickMod();
             }
-            else{
-                await dialog.showMessageBox(Main.mainWindow, {
-                    type: "error",
-                    title: "Mod Removal Error",
-                    message: "Mod cannot be removed. Please try to remove them manually.",
-                    buttons: ["OK"]
-                });
-            }
         }
-        catch(e){
+        catch (error) {
             progressBar.setCompleted();
             progressBar.close();
-            var errorString;
-            if(e.toString().includes("EBUSY")){
-                errorString = "Mod file(s) were busy or in use. You cannot remove a mod if TF2 is still running.\nSome files may not be deleted and some may remain.\nClose TF2 and try removing the mod again.";
-            }
-            else{
-                errorString = e.toString();
-            }
+            var errorString = (error.toString().includes("EBUSY"))
+                ? "Mod file(s) were busy or in use. You cannot remove a mod if TF2 is still running.\nSome files may not be deleted and some may remain.\nClose TF2 and try removing the mod again."
+                : error.toString();
 
             await ErrorDialog(`Mod Removal Failed.\n${errorString}`, "Mod Removal Error");
             this.FakeClickMod();
         }
     }
 
+    private async removeModFromConfig() {
+        for (let i = 0; i < Main.config.current_mod_versions.length; i++) {
+            let element = Main.config.current_mod_versions[i];
+            if (element.name && element.name == this.currentModData.name) {
+                Main.config.current_mod_versions.splice(i, 1);
+            }
+        }
+        await config.SaveConfig(Main.config);
+    }
+
     //Get the mod data object by the given name.
-    static GetModDataByName(name){
-        if(this.all_mods_data){
-            for (let i = 0; i < this.all_mods_data.mods.length; i++) {
-                const element = this.all_mods_data.mods[i];
-                if(element.name && element.name == name){
-                    return element;
+    private GetModDataByName(name): ModListEntry {
+        if (this.modList) {
+            for (let i = 0; i < this.modList.mods.length; i++) {
+                const modEntry = this.modList.mods[i];
+                if (modEntry.name && modEntry.name == name) {
+                    return modEntry;
                 }
             }
         }
@@ -474,7 +440,7 @@ class ModManager {
     }
 
     //Find the current version of the mod given by name that we have in our config. No version means it is not installed.
-    static GetCurrentModVersionFromConfig(name) {
+    GetCurrentModVersionFromConfig(name): any {
         let toReturn = null;
         for (let i = 0; i < Main.config.current_mod_versions.length; i++) {
             let element = Main.config.current_mod_versions[i];
@@ -491,11 +457,11 @@ class ModManager {
         }
     }
 
-    static GetRealInstallPath(){
+    private GetRealInstallPath(): string {
         let realPath = this.currentModData.install.targetdirectory;
 
         //To ensure the path is correct when resolved. Good one Zonical.
-        if(!realPath.endsWith("/") && !realPath.endsWith("\\")){
+        if (!realPath.endsWith("/") && !realPath.endsWith("\\")) {
             realPath += "/";
         }
 
@@ -504,19 +470,19 @@ class ModManager {
         return path.normalize(realPath.replace("{tf2_dir}", Main.config.tf2_directory));
     }
 
-    static async InstallFiles(files){
+    private async InstallFiles(files): Promise<void> {
         //Sort files based on their handle function.
         let sortedFiles = new Map();
-        for(let i = 0; i < files.length; i++){
-            let f = files[i];
-            let handleF = GetFileWriteFunction(f.extension);
+        for (let i = 0; i < files.length; i++) {
+            let file = files[i];
+            let handleF = GetFileWriteFunction(file.extension);
 
-            if(!sortedFiles.has(handleF)){
+            if (!sortedFiles.has(handleF)) {
                 //Add the map value for this handle function and set its value as an empty array.
                 sortedFiles.set(handleF, []);
             }
-            
-            sortedFiles.get(handleF).push(f);
+
+            sortedFiles.get(handleF).push(file);
         }
 
         let fileEntries = sortedFiles.entries();
@@ -527,13 +493,13 @@ class ModManager {
 
         let entryProcess = async () => {
             entry = fileEntries.next();
-            if(entry != null){
+            if (entry != null) {
                 func = entry.value[0];
             }
-            
+
             await func(this.GetRealInstallPath(), entry.value[1], this.currentModData);
             entryIndex++;
-            if(entryIndex < sortedFiles.size){
+            if (entryIndex < sortedFiles.size) {
                 await entryProcess();
             }
         };
@@ -542,37 +508,61 @@ class ModManager {
         await entryProcess();
     }
 
-    static FakeClickMod(){
+    private FakeClickMod(): void {
         //Send to trigger a reload of the mod in the UI. We can just trigger the mod change again in the ui now to update everything.
         //This sends an event to the render thread that we subscribe to.
         setTimeout(() => {
             Main.mainWindow.webContents.send("FakeClickMod", this.currentModData);
         }, 50);
     }
+
+    private loadModData(name: any): void {
+        this.currentModData = this.GetModDataByName(name);
+        this.currentModVersion = this.GetCurrentModVersionFromConfig(name);
+        this.currentModState = State.NotInstalled;
+        this.currentModVersionRemote = 0;
+        ElectronLog.log(`Set current mod to: ${this.currentModData.name}`);
+    }
+
+    private currentModNotInstalled(): boolean {
+        return this.currentModVersion == null || this.currentModVersion == 0;
+    }
+
+    private setModInstallSource(): void {
+        switch (this.currentModData.install.type) {
+            case "jsonlist":
+                this.modInstallSource = new JsonListSource(this.currentModData.install);
+                break;
+            case "github":
+                this.modInstallSource = new GithubSource(this.currentModData.install);
+                break;
+            default:
+                this.modInstallSource = null;
+                throw new Error("Mod install type was not recognised: " + this.currentModData.install.type);
+        }
+    }
 }
+export const modManager = new ModManager();
 
-export default ModManager;
-
-async function Delay(ms)
-{
+async function Delay(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));
 }
-function DownloadFiles_UI(urls){
+function DownloadFiles_UI(urls) {
     var currentIndex = 0;
     var files = [];
 
     return new Promise((resolve, reject) => {
         var progressBar;
-        var shouldStop = {value: false};
+        var shouldStop = { value: false };
 
         let maxProgressVal = 0;
 
         var progressFunction = (dataLength) => {
-            if(progressBar && !progressBar.isCompleted()){
-                try{
+            if (progressBar && !progressBar.isCompleted()) {
+                try {
                     progressBar.value = dataLength;
                 }
-                catch(e){
+                catch (e) {
                     reject(e.toString());
                 }
             }
@@ -608,23 +598,23 @@ function DownloadFiles_UI(urls){
 
             //Setup events to display data.
             progressBar
-            .on('completed', function () {
-                //progressBar.detail = 'Download Finished!';
-            })
-            .on('aborted', function (value) { 
-                shouldStop.value = true;
-                reject("Download Cancelled by User!");
-            })
-            .on('progress', function(value) {
-                try{
-                progressBar.detail = `[File ${currentIndex + 1} of ${urls.length}] Downloaded ${(Math.round((value / 1000000) * 100) / 100).toFixed(2)} MB out of ${maxProgressVal} MB.`;
-                }
-                catch( e ){
-                    reject(e.toString());
-                }
-            });
+                .on('completed', function () {
+                    //progressBar.detail = 'Download Finished!';
+                })
+                .on('aborted', function (value) {
+                    shouldStop.value = true;
+                    reject("Download Cancelled by User!");
+                })
+                .on('progress', function (value) {
+                    try {
+                        progressBar.detail = `[File ${currentIndex + 1} of ${urls.length}] Downloaded ${(Math.round((value / 1000000) * 100) / 100).toFixed(2)} MB out of ${maxProgressVal} MB.`;
+                    }
+                    catch (e) {
+                        reject(e.toString());
+                    }
+                });
 
-            maxProgressVal = Math.round((parseInt(contentLength) / 1000000) * 100) / 100;           
+            maxProgressVal = Math.round((parseInt(contentLength) / 1000000) * 100) / 100;
         };
 
         //Setup download sequence for all files
@@ -634,12 +624,12 @@ function DownloadFiles_UI(urls){
                 files.push(file);
                 currentIndex++;
 
-                if(currentIndex >= urls.length){
+                if (currentIndex >= urls.length) {
                     progressBar.setCompleted();
                     progressBar.close();
                     resolve(files);
                 }
-                else{
+                else {
                     progressBar.setCompleted();
                     progressBar.close();
                     setTimeout(downloadFunc, 50);
@@ -658,7 +648,7 @@ function DownloadFiles_UI(urls){
 
 //Get all the files that exist in this zip file object and create them in the target directory.
 //Also supports multiple zips to install at once.
-async function WriteZIPsToDirectory(targetPath, zips, currentModData){
+async function WriteZIPsToDirectory(targetPath, zips, currentModData) {
     var inProgress = 0;
     var written = 0;
     var currentZip;
@@ -692,7 +682,7 @@ async function WriteZIPsToDirectory(targetPath, zips, currentModData){
     //Make JSZip object from each of the zips given
     let zipConvertsInProgress = 0;
 
-    for(let i = 0; i < zips.length; i++){
+    for (let i = 0; i < zips.length; i++) {
         zipConvertsInProgress++;
         let index = i;
         const jszip = await JSZip.loadAsync(zips[index].buffer);
@@ -710,25 +700,25 @@ async function WriteZIPsToDirectory(targetPath, zips, currentModData){
         progressBar.detail = `Wrote ${name}. Total Files Written: ${written}.`;
 
         //Add file that we wrote to the file list
-        if(!files_object.files.includes(fullFilePath)) files_object.files.push(fullFilePath);
+        if (!files_object.files.includes(fullFilePath)) files_object.files.push(fullFilePath);
 
         ElectronLog.log(`ZIP extract for "${name}" was successful.`);
         inProgress--;
     };
 
     const HandleFile = async (relativePath, file) => {
-        if(!active){
+        if (!active) {
             return;
         }
 
         inProgress++;
-        if(file.dir){
+        if (file.dir) {
             let directory = path.join(targetPath, file.name);
 
             await fsPromises.ensureDirectoryExists(directory);
             inProgress--;
         }
-        else{
+        else {
             try {
                 const d = await currentZip.file(file.name).async("uint8array");
                 await Write(file.name, d);
@@ -740,13 +730,13 @@ async function WriteZIPsToDirectory(targetPath, zips, currentModData){
     };
 
     progressBar
-    .on('completed', function() {
-        progressBar.detail = 'Extraction completed. Exiting...';
-    })
-    .on('aborted', function() {
-        active = false;
-        throw new Error("Extraction aborted by user. You will need to re start the installation process to install this mod.");
-    });
+        .on('completed', function () {
+            progressBar.detail = 'Extraction completed. Exiting...';
+        })
+        .on('aborted', function () {
+            active = false;
+            throw new Error("Extraction aborted by user. You will need to re start the installation process to install this mod.");
+        });
 
     const HandleZips = async (zips) => {
         const promises = [];
@@ -760,15 +750,15 @@ async function WriteZIPsToDirectory(targetPath, zips, currentModData){
     const DoExtract = async () => {
         ElectronLog.log("Waiting for ZIP exraction to complete...")
         await HandleZips(currentZip);
-        
+
         let checkFunc = async () => {
-            if(inProgress <= 0){
+            if (inProgress <= 0) {
                 inProgress = 0;
 
-                if(multipleZips){
+                if (multipleZips) {
                     currentIndex++;
                     //If we have another zip to install.
-                    if(currentIndex < zips.length){
+                    if (currentIndex < zips.length) {
                         //Assign the new zip and repeat the processess to handle and write the files.
                         currentZip = zips[currentIndex];
                         await HandleZips(currentZip);
@@ -783,13 +773,13 @@ async function WriteZIPsToDirectory(targetPath, zips, currentModData){
                         return;
                     }
                 }
-                else{
+                else {
                     //Resolve now as we only had one zip to install.
                     progressBar.setCompleted();
                     await filemanager.SaveFileList(files_object, currentModData.name);
                     return;
                 }
-                
+
             }
             else {
                 await Delay(200);
@@ -802,22 +792,22 @@ async function WriteZIPsToDirectory(targetPath, zips, currentModData){
         await checkFunc();
     }
 
-    const CheckZipCreateDone = async() => {
-        if(zipConvertsInProgress <= 0){
+    const CheckZipCreateDone = async () => {
+        if (zipConvertsInProgress <= 0) {
 
             //Get the target zip.
-            if(!Array.isArray(zips)){
+            if (!Array.isArray(zips)) {
                 currentZip = zips;
                 multipleZips = false;
             }
-            else{
+            else {
                 currentZip = zips[0];
                 multipleZips = true;
             }
 
             await DoExtract();
         }
-        else{
+        else {
             await Delay(50);
             await CheckZipCreateDone();
         }
@@ -828,11 +818,11 @@ async function WriteZIPsToDirectory(targetPath, zips, currentModData){
 }
 
 //Writes files to disk that are not in a zip but are just a buffer.
-async function WriteFilesToDirectory(targetPath, files, currentModData){
+async function WriteFilesToDirectory(targetPath, files, currentModData) {
     var written = 0;
 
     //Load file list object
-    let files_object = await filemanager.GetFileList(currentModData.name);
+    let loadedFiles = await filemanager.GetFileList(currentModData.name);
     var active = true;
 
     await fsPromises.ensureDirectoryExists(targetPath);
@@ -858,79 +848,80 @@ async function WriteFilesToDirectory(targetPath, files, currentModData){
     });
 
     progressBar
-    .on('completed', function() {
-        active = false;
-        progressBar.detail = 'Writing completed. Exiting...';
-    })
-    .on('aborted', function() {
-        active = false;
-        throw new Error("User aborted file writing. You will need to restart the installation process to install this mod.");
-    });
-    
+        .on('completed', function () {
+            active = false;
+            progressBar.detail = 'Writing completed. Exiting...';
+        })
+        .on('aborted', function () {
+            active = false;
+            throw new Error("User aborted file writing. You will need to restart the installation process to install this mod.");
+        });
+
     ElectronLog.log("Waiting for File writing to complete...")
 
     for (let index = 0; index < files.length; index++) {
-        if(!active){
+        if (!active) {
             continue;
         }
         const file = files[index];
         progressBar.detail = `Writing ${file.name}. Total Files Written: ${written}.`;
 
         let fullFilePath = path.join(targetPath, file.name);
-
         await fsPromises.writeFile(fullFilePath, file.buffer);
         written++;
 
         //Add file that we wrote to the file list
-        if(!files_object.files.includes(fullFilePath)) files_object.files.push(fullFilePath);
+        if (!loadedFiles.files.includes(fullFilePath)) {
+            loadedFiles.files.push(fullFilePath);
+        }
 
         ElectronLog.log(`File write for '${file.name}' was successful.`);
     }
 
     progressBar.setCompleted();
-    await filemanager.SaveFileList(files_object, currentModData.name);
+    await filemanager.SaveFileList(loadedFiles, currentModData.name);
     return;
 }
 
 //Validates the tf2 directory. Can trigger dialogues depending on the outcome.
-async function ValidateTF2Dir(){
+async function ValidateTF2Dir() {
     //Check we have a config object
-    if(!Main.config){
+    if (!Main.config) {
         await ErrorDialog("The application could not load the config. It may have failed to write it to disk.\nPlease report this issue!", "Internal Error");
         return false;
     }
 
     //If no path is specified. Maybe the auto locate failed?
-    if(Main.config.tf2_directory == ""){
+    if (Main.config.tf2_directory == "") {
         await ErrorDialog("No TF2 path has been specified. Please manually enter this in the Settings.\nE.g. 'C:\\Program Files (x86)\\steam\\steamapps\\common\\Team Fortress 2\\'", "TF2 Path Error");
         return false;
     }
 
     //Check if the directory actually exists.
-    if(!await fsPromises.pathExists(Main.config.tf2_directory)){
+    if (!await fsPromises.pathExists(Main.config.tf2_directory)) {
         await ErrorDialog("The current TF2 directory specified does not exist. Please check your settings.", "TF2 Path Error");
         return false;
     }
 
     //Check if the directory contains an hl2 win32 executable if we are on windows.
     const plat = os.platform();
-    if(plat == "win32"){
-        if(await fsPromises.fileExists(path.join(Main.config.tf2_directory, "hl2.exe"))){
-            return true;
-        }
-    }    
-    else if (plat == "linux" || plat == "freebsd" || plat == "openbsd"){
-        if(await fsPromises.pathExists(path.join(Main.config.tf2_directory, "hl2_linux"))){
+    if (plat == "win32") {
+        if (await fsPromises.fileExists(path.join(Main.config.tf2_directory, "hl2.exe"))) {
             return true;
         }
     }
-    
+    else if (plat == "linux" || plat == "freebsd" || plat == "openbsd") {
+        if (await fsPromises.pathExists(path.join(Main.config.tf2_directory, "hl2_linux"))) {
+            return true;
+        }
+    }
+
     //Check if the directory has the app id txt and it has 440 in it.
     let appid_path = path.join(Main.config.tf2_directory, "steam_appid.txt");
-    if(await fsPromises.fileExists(appid_path)){
-        let content = await fsPromises.readFile(appid_path, {encoding: "utf8"});
+    if (await fsPromises.fileExists(appid_path)) {
+        let content = await fsPromises.readFile(appid_path, { encoding: "utf8" });
         let appid = content.split("\n")[0];
-        if(appid != null && appid == "440"){
+        if (appid != null && appid == "440") {
             return true;
         }
     }
@@ -940,29 +931,29 @@ async function ValidateTF2Dir(){
     return false;
 }
 
-function DownloadFile(_url, progressFunc, responseHeadersFunc, shouldStop){
+function DownloadFile(_url, progressFunc, responseHeadersFunc, shouldStop) {
     return new Promise((resolve, reject) => {
 
         var options = {
             headers: {
-              'User-Agent': 'creators-tf-launcher'
+                'User-Agent': 'creators-tf-launcher'
             }
         };
 
         var DoRequest = (__url, retries) => {
-            if(retries <= 0){
-               let error = `Endpoint ${_url} redirected too many times. Aborted!`;
-               ElectronLog.error(error);
-               reject(error);
-            } 
+            if (retries <= 0) {
+                let error = `Endpoint ${_url} redirected too many times. Aborted!`;
+                ElectronLog.error(error);
+                reject(error);
+            }
 
             ElectronLog.log("Starting GET for file data at: " + __url);
             var req = https.get(__url, function (res) {
-                if(res.statusCode == 302){
+                if (res.statusCode == 302) {
                     ElectronLog.log("Got a 302, re trying on new location.");
                     DoRequest(res.headers.location, retries--);
                 }
-                else if (res.statusCode == 404){
+                else if (res.statusCode == 404) {
                     let error = `Remote Mod file was not able to be found. Try again later.\nIf this persists please report this error.`;
                     ElectronLog.error(error);
                     ElectronLog.error("404 for: " + _url);
@@ -975,15 +966,15 @@ function DownloadFile(_url, progressFunc, responseHeadersFunc, shouldStop){
                 }
                 else {
                     //Execute the callback for doing processing with the headers.
-                    if(responseHeadersFunc != null) responseHeadersFunc(res.headers);
-    
+                    if (responseHeadersFunc != null) responseHeadersFunc(res.headers);
+
                     var data = [], dataLen = 0;
-    
+
                     // don't set the encoding, it will break everything !
                     // or, if you must, set it to null. In that case the chunk will be a string.
-    
+
                     res.on("data", function (chunk) {
-                        if(shouldStop.value){
+                        if (shouldStop.value) {
                             res.destroy();
                             reject();
                             return;
@@ -991,41 +982,41 @@ function DownloadFile(_url, progressFunc, responseHeadersFunc, shouldStop){
 
                         data.push(chunk);
                         dataLen += chunk.length;
-                        if(progressFunc != null) progressFunc(dataLen);
+                        if (progressFunc != null) progressFunc(dataLen);
                     });
-    
+
                     res.on("end", function () {
-                        if(!shouldStop.value){
+                        if (!shouldStop.value) {
                             var buf = Buffer.concat(data);
-        
+
                             progressFunc = null;
                             responseHeadersFunc = null;
-                            
+
                             ElectronLog.log("File download finished. Returning raw data.");
                             //This approach to get the file name only works for direct file urls.
                             //A better solution for later would be via the content-disposition header if this is missing.
                             var filename;
                             var contentDispositionHeader = res.headers["content-disposition"];
-                            if(contentDispositionHeader != undefined){
+                            if (contentDispositionHeader != undefined) {
                                 const filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
                                 var matches = filenameRegex.exec(contentDispositionHeader);
-                                if (matches != null && matches[1]) { 
+                                if (matches != null && matches[1]) {
                                     filename = matches[1].replace(/['"]/g, '');
                                     ElectronLog.info("Got filename for download fron content-disposition header: " + filename);
                                 }
                             }
 
-                            if(filename == undefined) filename = GetFileName(__url);
+                            if (filename == undefined) filename = GetFileName(__url);
 
                             resolve(new DownloadedFile(buf, filename));
                         }
-                        else{
+                        else {
                             ElectronLog.log("File download was cancled by the user successfully.");
                         }
                     });
                 }
             });
-    
+
             req.on("error", function (err) {
                 ElectronLog.error(`File download request for ${_url} errored out: ` + err);
                 reject(err);
@@ -1037,16 +1028,16 @@ function DownloadFile(_url, progressFunc, responseHeadersFunc, shouldStop){
     });
 }
 
-function GetFileName(_url){
+function GetFileName(_url) {
     var parsed = url.parse(_url);
     return path.basename(parsed.pathname);
 }
 
-function SetNewModVersion(version, currentModName){
+function SetNewModVersion(version, currentModName) {
     //Try to update the version of the mod if its already in the array.
-    for(let i = 0; i < Main.config.current_mod_versions.length; i++){
+    for (let i = 0; i < Main.config.current_mod_versions.length; i++) {
         let modVersionObject = Main.config.current_mod_versions[i];
-        if(modVersionObject.name == currentModName){
+        if (modVersionObject.name == currentModName) {
             ElectronLog.log(`Mod ${currentModName} version was updated from ${modVersionObject.version} to ${version}`);
             modVersionObject.version = version;
             return true;
@@ -1055,7 +1046,7 @@ function SetNewModVersion(version, currentModName){
     return false;
 }
 
-async function ErrorDialog(error, title){
+async function ErrorDialog(error, title) {
     ElectronLog.error(`Error Dialog shown: ${title} : ${error.toString()}.\nError Stack:${error.stack}`);
     await dialog.showMessageBox(Main.mainWindow, {
         type: "error",
@@ -1065,7 +1056,7 @@ async function ErrorDialog(error, title){
     });
 }
 
-async function FatalError(errorMessage){
+async function FatalError(errorMessage) {
     await dialog.showMessageBox(Main.mainWindow, {
         type: "error",
         title: "Fatal Error",
@@ -1076,11 +1067,11 @@ async function FatalError(errorMessage){
     Main.app.quit();
 }
 
-function GetFileWriteFunction(extension){
+function GetFileWriteFunction(extension) {
     //Format to be what we expect.
     extension = extension.toLowerCase().replace(".", "");
 
-    if(functionMap.has(extension)){
+    if (functionMap.has(extension)) {
         return functionMap.get(extension);
     }
 
@@ -1091,6 +1082,6 @@ functionMap.set("zip", WriteZIPsToDirectory);
 functionMap.set("vpk", WriteFilesToDirectory);
 
 //Some extras to check just incase the downloads are not something we can handle or a windows exe.
-functionMap.set("rar", async() => { await FatalError("Cannot handle .rar files currently. This should not happen. Exiting..."); });
-functionMap.set("7z", async() => { await FatalError("Cannot handle .7z files currently. This should not happen. Exiting..."); });
-functionMap.set("exe", async() => { await FatalError("Downloaded file was windows executable. This should not happen, exiting. File was not written."); });
+functionMap.set("rar", async () => { await FatalError("Cannot handle .rar files currently. This should not happen. Exiting..."); });
+functionMap.set("7z", async () => { await FatalError("Cannot handle .7z files currently. This should not happen. Exiting..."); });
+functionMap.set("exe", async () => { await FatalError("Downloaded file was windows executable. This should not happen, exiting. File was not written."); });

--- a/modules/mod_sources/github_source.ts
+++ b/modules/mod_sources/github_source.ts
@@ -1,37 +1,29 @@
-import  ModInstallSource from "./mod_source_base.js";
+import ModInstallSource from "./mod_source_base.js";
 import https from "https";
 
 // Reference: https://developer.github.com/v3/repos/releases/#list-releases
 
-const github_api_url = "https://api.github.com/";
+const githubApiUrl = "https://api.github.com/";
 
 class GithubSource extends ModInstallSource {
-    github_data = null;
+    githubData = null;
     fileType = "FILE";
 
-    constructor(install_data){
+    constructor(install_data) {
         super(install_data);
     }
 
-    //Function to get the latest github data from memory or request.
-    async _GetGithubData(): Promise<any>{
+    async GetLatestVersionNumber(): Promise<number> {
         return new Promise((resolve, reject) => {
-            if(this.github_data != null) resolve(this.github_data);
-            else {
-                this._GetGitHubReleaseData().then(resolve).catch(reject);
-            }
-        });
-    }
-
-    async GetLatestVersionNumber() : Promise<number>{
-        return new Promise((resolve, reject) => {
-            this._GetGithubData().then((data) => {
-                if(data.length == null || data.length == 0) reject("No releases avaliable to download");
+            this.GetGitHubData().then((data) => {
+                if (data.length == null || data.length == 0) {
+                    reject("No releases avaliable to download");
+                }
 
                 let date = data[0].published_at;
                 date = date.split("T")[0];
                 date = date.replace(/-/g, "");
-                
+
                 resolve(date);
             }).catch(reject);
         });
@@ -39,58 +31,72 @@ class GithubSource extends ModInstallSource {
 
     async GetDisplayVersionNumber(): Promise<string> {
         let versionNumber = await this.GetLatestVersionNumber();
-        let githubData = await this._GetGithubData();
+        let githubData = await this.GetGitHubData();
         return `${githubData[0].name} (${versionNumber})`;
     }
 
-    async GetFileURL() : Promise<string>{
+    async GetFileURL(): Promise<string> {
         return new Promise((resolve, reject) => {
             //Try to get the download url for the release asset.
-            this._GetGithubData().then((data) => {
+            this.GetGitHubData().then((data) => {
                 let releaseAssets = data[0].assets;
-                if(releaseAssets != null && releaseAssets != []){
+                if (releaseAssets != null && releaseAssets != []) {
                     let asset;
-                    
-                    if(this.data.hasOwnProperty("asset_index")) asset = releaseAssets[this.data.asset_index];
+
+                    if (this.data.hasOwnProperty("asset_index")) asset = releaseAssets[this.data.asset_index];
                     else asset = releaseAssets[0];
 
-                    if(asset != null){
+                    if (asset != null) {
                         resolve(asset.browser_download_url);
                     }
 
                     reject("This Github repositorys latest release was missing a usable asset.");
                 }
                 else reject("This Github repository has no releases avaliable.");
-             }).catch(reject);
+            }).catch(reject);
         });
     }
 
-    _GetGitHubReleaseData(){
+    //Function to get the latest github data from memory or request.
+    private async GetGitHubData(): Promise<any> {
+        return new Promise((resolve, reject) => {
+            if (this.githubData != null) {
+                resolve(this.githubData);
+            }
+            else {
+                this.GetGitHubReleaseData()
+                    .then(resolve)
+                    .catch(reject);
+            }
+        });
+    }
+
+    private GetGitHubReleaseData() {
         return new Promise((resolve, reject) => {
             //Construct initial request url to github api
-            let url = github_api_url + `repos/${this.data.owner}/${this.data.name}/releases`;
+            let releaseUrl = `${githubApiUrl}repos/${this.data.owner}/${this.data.name}/releases`;
             var options = {
                 headers: {
-                  'User-Agent': 'creators-tf-launcher'
+                    'User-Agent': 'creators-tf-launcher'
                 }
             };
 
-            var data = [], dataLen = 0;
+            var data = [];
 
-            let req = https.get(url, options, res => {
-            console.log(`statusCode: ${res.statusCode}`);
+            let req = https.get(releaseUrl, options, res => {
+                console.log(`statusCode: ${res.statusCode}`);
                 res.on('data', d => {
-                    if(res.statusCode != 200){
-                        reject(`Failed accessing ${url}: ` + res.statusCode);
+                    if (res.statusCode != 200) {
+                        reject(`Failed accessing ${releaseUrl}: ` + res.statusCode);
                         return;
                     }
-                    
+
                     data.push(d);
                 });
 
                 res.on("end", function () {
-                    var buf = Buffer.concat(data);
-                    let parsed = JSON.parse(buf.toString());
+                    var buffer = Buffer.concat(data);
+                    let parsed = JSON.parse(buffer.toString());
                     resolve(parsed);
                 });
             });
@@ -98,7 +104,7 @@ class GithubSource extends ModInstallSource {
             req.on('error', error => {
                 reject(error.toString());
             });
-            
+
             req.end();
         });
     }

--- a/modules/mod_sources/jsonlist_source.ts
+++ b/modules/mod_sources/jsonlist_source.ts
@@ -10,26 +10,26 @@ class JsonListSource extends ModInstallSource {
     fileType = "ARCHIVE";
     jsonlist_data = null;
 
-    constructor(install_data){
+    constructor(install_data) {
         super(install_data);
         this.url = install_data.get_url;
 
         //If this property is present, lets add a random query on the end of the URL to get an un cached version of this file.
-        if(install_data.cloudflarebypass != null){
+        if (install_data.cloudflarebypass != null) {
             this.url += `?${Math.floor(Math.random() * 1000000000)}`;
         }
     }
 
-    GetJsonData() : Promise<any>{
+    GetJsonData(): Promise<any> {
         return new Promise((resolve, reject) => {
-            if(this.jsonlist_data == null){
+            if (this.jsonlist_data == null) {
                 this.GetJsonReleaseData().then(resolve).catch(reject);
             }
             else resolve(this.jsonlist_data);
         });
     }
 
-    GetLatestVersionNumber() : Promise<number>{
+    GetLatestVersionNumber(): Promise<number> {
         return new Promise((resolve, reject) => {
             this.GetJsonData().then((json_data) => {
                 resolve(json_data[this.data.version_property_name]);
@@ -41,7 +41,7 @@ class JsonListSource extends ModInstallSource {
         return await this.GetLatestVersionNumber().toString();
     }
 
-    GetFileURL() : Promise<string>{
+    GetFileURL(): Promise<string> {
         return new Promise((resolve, reject) => {
             this.GetJsonData().then((json_data) => {
                 resolve(json_data[this.data.install_url_property_name]);
@@ -49,7 +49,7 @@ class JsonListSource extends ModInstallSource {
         });
     }
 
-    GetJsonReleaseData(){
+    GetJsonReleaseData() {
         return new Promise((resolve, reject) => {
             var data = [];
 
@@ -63,7 +63,7 @@ class JsonListSource extends ModInstallSource {
                 console.log(`statusCode: ${res.statusCode}`);
 
                 res.on('data', d => {
-                    if(res.statusCode == 503){
+                    if (res.statusCode == 503) {
                         reject(cloudFlareMessage);
                         return;
                     }
@@ -71,35 +71,35 @@ class JsonListSource extends ModInstallSource {
                     data.push(d);
                 });
 
-                res.on("end",  () => {
-                    try{
+                res.on("end", () => {
+                    try {
                         var buf = Buffer.concat(data);
-                        if(res.statusCode == 503){
+                        if (res.statusCode == 503) {
                             reject(cloudFlareMessage);
                             return;
                         }
-                        else if(res.statusCode != 200){
+                        else if (res.statusCode != 200) {
                             reject(`Failed accessing ${this.url}: ${res.statusCode}.`);
                             ElectronLog.error(buf.toString());
                             return;
                         }
-                        else{
+                        else {
                             let parsed = JSON.parse(buf.toString());
                             resolve(parsed);
                         }
                     }
-                    catch (error){
+                    catch (error) {
                         //Json parsing failed soo reject.
                         ElectronLog.error("Json parse failed. Endpoint is probably not returning valid JSON. Site may be down!");
                         reject(error.toString());
                     }
                 });
             });
-            
+
             req.on('error', error => {
                 reject(error);
             });
-            
+
             req.end();
         });
     }

--- a/modules/mod_sources/mod_source_base.ts
+++ b/modules/mod_sources/mod_source_base.ts
@@ -2,11 +2,11 @@ abstract class ModInstallSource {
     data: any;
     fileType = "UNKNOWN";
 
-    constructor(install_data){
+    constructor(install_data) {
         this.data = install_data;
     }
-    abstract GetLatestVersionNumber() : Promise<number>;
+    abstract GetLatestVersionNumber(): Promise<number>;
     abstract GetDisplayVersionNumber(): Promise<string>;
-    abstract GetFileURL() : Promise<string>;
+    abstract GetFileURL(): Promise<string>;
 }
 export default ModInstallSource

--- a/modules/utilities.ts
+++ b/modules/utilities.ts
@@ -3,7 +3,7 @@ import fs from "fs";
 import process from "process";
 import path from "path";
 const ProgressBar = require('electron-progressbar');
-const {app} = require("electron");
+const { app } = require("electron");
 import log from "electron-log";
 
 const loadingTextStyle = {
@@ -17,7 +17,7 @@ class Utilities {
      * @param error The error object/message.
      * @param title Title for the error dialog.
      */
-    static ErrorDialog(error : any, title : string){
+    static ErrorDialog(error: any, title: string) {
         //@ts-ignore
         global.log.error(`Error Dialog shown: ${title} : ${error.toString()}`);
         //@ts-ignore
@@ -32,20 +32,29 @@ class Utilities {
     /**
      * Get the data folder dynamically based on the platform.
      */
-    static GetDataFolder() : string {
-        let _path = (process.env.APPDATA || (process.platform == 'darwin' ? process.env.HOME + '/Library/Preferences' : process.env.HOME + "/.local/share")) + "/creators-tf-launcher";
-        
-        if(!fs.existsSync(_path)) fs.mkdirSync(_path);
+    static GetDataFolder(): string {
+        let path = this.getDataFolderPath();
 
-        return _path;
+        if (!fs.existsSync(path)) {
+            fs.mkdirSync(path);
+        }
+
+        return path;
     }
 
-    static GetLogsFolder() : string {
+    private static getDataFolderPath(): string {
+        const systemDataFolder = process.platform == 'darwin'
+            ? process.env.HOME + '/Library/Preferences'
+            : process.env.HOME + "/.local/share";
+        return process.env.APPDATA || systemDataFolder + '/creators-tf-launcher';
+    }
+
+    static GetLogsFolder(): string {
         return log.transports.file.getFile().path;
     }
 
 
-    static GetNewLoadingPopup(title : string, mainWindow : any, onCanceled: () => void) : any {
+    static GetNewLoadingPopup(title: string, mainWindow: any, onCanceled: () => void): any {
         var progressBar = new ProgressBar({
             text: title,
             detail: '...',
@@ -65,9 +74,9 @@ class Utilities {
                 value: loadingTextStyle
             }
         }, app);
-        
+
         progressBar
-        .on('aborted', onCanceled);
+            .on('aborted', onCanceled);
 
         return progressBar;
     }
@@ -75,17 +84,18 @@ class Utilities {
     static currentLauncherVersion = null;
 
     static GetCurrentVersion() {
-        if (this.currentLauncherVersion == null) {
-            try {
-                let packageJson = fs.readFileSync(path.join(__dirname, "../package.json"));
-                this.currentLauncherVersion = JSON.parse(packageJson.toString()).version;
-            }
-            catch {
-                return null;
-            }
+        if (this.currentLauncherVersion != null) {
+            return this.currentLauncherVersion;
         }
-        return this.currentLauncherVersion;
+        
+        try {
+            let packageJson = fs.readFileSync(path.join(__dirname, "../package.json"));
+            this.currentLauncherVersion = JSON.parse(packageJson.toString()).version;
+        }
+        catch {
+            return null;
+        }
     }
 }
 
-export {Utilities};
+export { Utilities };

--- a/renderer.js
+++ b/renderer.js
@@ -35,18 +35,18 @@ const defaultBackgroundImage = "images/backgrounds/servers.jpg";
 function OnClick_Mod(data) {
     window.log.info("Mod entry clicked: " + data.name);
 
-    
+
     var bgImg;
-    if(data.backgroundimage != ""){
+    if (data.backgroundimage != "") {
         bgImg = data.backgroundimage;
     }
-    else{
+    else {
         bgImg = defaultBackgroundImage;
     }
 
     content.style.backgroundImage = `url("${"./" + bgImg}")`;
 
-    if(data.titleimage == ""){
+    if (data.titleimage == "") {
         titleheader.style.display = "block";
         titleheader.innerText = data.name;
         titleImage.style.display = "none";
@@ -125,13 +125,13 @@ window.ipcRenderer.on("update_downloaded", () => {
     window.log.info("The update was downloaded and will be installed on restart. Waiting for user's input.");
 });
 
-document.getElementById("settings-button").addEventListener("click", (a,b) => {
+document.getElementById("settings-button").addEventListener("click", (a, b) => {
     window.ipcRenderer.send("SettingsWindow", "");
 });
-document.getElementById("patchnotes-button").addEventListener("click", (a,b) => {
+document.getElementById("patchnotes-button").addEventListener("click", (a, b) => {
     window.ipcRenderer.send("PatchNotesWindow", "");
 });
-document.getElementById("serverlist").addEventListener("click", (a,b) => {
+document.getElementById("serverlist").addEventListener("click", (a, b) => {
     window.ipcRenderer.send("ServerListWindow", "");
 });
 
@@ -153,7 +153,7 @@ window.ipcRenderer.on("InstallButtonName-Reply", (event, arg) => {
         installButton.disabled = false;
     }
 
-    switch(arg) {
+    switch (arg) {
         case "installed":
             installButton.style.background = "linear-gradient(to right, #009028 35%, #006419 75%)"; //Green (light-to-dark)
             removeButton.style.display = "block";
@@ -182,6 +182,6 @@ window.ipcRenderer.on("FakeClickMod", (event, moddata) => {
     OnClick_Mod(moddata);
 });
 
-removeButton.addEventListener("click", function(e) {
+removeButton.addEventListener("click", function (e) {
     window.ipcRenderer.send("Remove-Mod", "");
 });


### PR DESCRIPTION
Mostly a cleanup PR. ModManager has some pretty large functions, so I broke them down to make it easier to follow. Added some return types to functions, renamed some variables and functions for clarity, fixed formatting with built-in VSCode formatter, etc.

Also, large static classes like ModManager are often an anti-pattern, so I updated it to be non-static.